### PR TITLE
お知らせ登録・編集画面作成

### DIFF
--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\News;
 
 /**
  * お知らせ
@@ -17,6 +18,27 @@ class NewsController extends Controller
 
     public function create()
     {
-        return view('news.create');
+        $news = new News;
+        return view('news.create', [
+            'news' => $news,
+        ]);
+    }
+
+    public function store()
+    {
+
+    }
+
+    public function edit($id)
+    {
+        $news = News::with('news_documents', 'news_links')->find($id);
+        return view('news.create', [
+            'news' => $news,
+        ]);
+    }
+
+    public function update($id)
+    {
+
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^9.19",
         "laravel/sanctum": "^3.0",
-        "laravel/tinker": "^2.7"
+        "laravel/tinker": "^2.7",
+        "laravelcollective/html": "^6.3"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7700948b70eeba2be3c22a6cdec329a",
+    "content-hash": "465cabe5cdff4ca9efcea8881239621a",
     "packages": [
         {
             "name": "brick/math",
@@ -1275,6 +1275,78 @@
                 "source": "https://github.com/laravel/tinker/tree/v2.7.3"
             },
             "time": "2022-11-09T15:11:38+00:00"
+        },
+        {
+            "name": "laravelcollective/html",
+            "version": "v6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/LaravelCollective/html.git",
+                "reference": "78c3cb516ac9e6d3d76cad9191f81d217302dea6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/LaravelCollective/html/zipball/78c3cb516ac9e6d3d76cad9191f81d217302dea6",
+                "reference": "78c3cb516ac9e6d3d76cad9191f81d217302dea6",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/http": "^6.0|^7.0|^8.0|^9.0",
+                "illuminate/routing": "^6.0|^7.0|^8.0|^9.0",
+                "illuminate/session": "^6.0|^7.0|^8.0|^9.0",
+                "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
+                "illuminate/view": "^6.0|^7.0|^8.0|^9.0",
+                "php": ">=7.2.5"
+            },
+            "require-dev": {
+                "illuminate/database": "^6.0|^7.0|^8.0|^9.0",
+                "mockery/mockery": "~1.0",
+                "phpunit/phpunit": "~8.5|^9.5.10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Collective\\Html\\HtmlServiceProvider"
+                    ],
+                    "aliases": {
+                        "Form": "Collective\\Html\\FormFacade",
+                        "Html": "Collective\\Html\\HtmlFacade"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Collective\\Html\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Adam Engebretson",
+                    "email": "adam@laravelcollective.com"
+                },
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylorotwell@gmail.com"
+                }
+            ],
+            "description": "HTML and Form Builders for the Laravel Framework",
+            "homepage": "https://laravelcollective.com",
+            "support": {
+                "issues": "https://github.com/LaravelCollective/html/issues",
+                "source": "https://github.com/LaravelCollective/html"
+            },
+            "time": "2022-02-08T21:02:54+00:00"
         },
         {
             "name": "league/commonmark",

--- a/resources/views/components/layout/container.blade.php
+++ b/resources/views/components/layout/container.blade.php
@@ -1,0 +1,3 @@
+<div class="px-[11%] s-pc:px-[6%] sp:px-[3%]">
+  {{ $slot }}
+</div>

--- a/resources/views/components/parts/form-button.blade.php
+++ b/resources/views/components/parts/form-button.blade.php
@@ -1,0 +1,27 @@
+@props([
+    "bgColor" => "orange",
+    "fontColor" => "white",
+])
+
+@php
+    if (!function_exists("getBgColorButton")) {
+        function getBgColorButton($theme) {
+            return match ($theme) {
+                "orange" => "bg-orange-400",
+                "red" => "bg-red-600",
+                "black" => "bg-black",
+            };
+        }
+    }
+    if (!function_exists("getFontColorButton")) {
+        function getFontColorButton($theme) {
+            return match ($theme) {
+                "white" => "text-white",
+                "black" => "text-black",
+            };
+        }
+    }
+@endphp
+
+{{ Form::submit($slot, ['class'=>'h-[50px] w-28'. ' ' . getBgColorButton($bgColor) . ' ' . getFontColorButton($fontColor)]) }}
+<p class=" items-center"></p>

--- a/resources/views/components/parts/title.blade.php
+++ b/resources/views/components/parts/title.blade.php
@@ -1,0 +1,1 @@
+<h3 class="text-4xl s-pc:text-3xl sp:text-2xl font-black">{{ $slot }}</h3>

--- a/resources/views/news/create.blade.php
+++ b/resources/views/news/create.blade.php
@@ -3,7 +3,12 @@
     <section>
         <x-layout.container>
             <div class="mt-32 mb-16">
-                <x-parts.title>お知らせ・大会情報登録</x-parts.title>
+                <x-parts.title>
+                    {{ count($news['news_links']) == 0 ?
+                        'お知らせ・大会情報登録' :
+                        'お知らせ・大会情報編集'
+                    }}
+                </x-parts.title>
             </div>
             {{ Form::open(['route' => 'admins.news.store']) }}
                 {{ Form::token() }}

--- a/resources/views/news/create.blade.php
+++ b/resources/views/news/create.blade.php
@@ -1,4 +1,86 @@
 <x-layout.layout>
     <!-- main -->
-    <section></section>
+    <section>
+        <x-layout.container>
+            <div class="mt-32 mb-16">
+                <x-parts.title>お知らせ・大会情報登録</x-parts.title>
+            </div>
+            {{ Form::open(['route' => 'admins.news.store']) }}
+                {{ Form::token() }}
+                {{ Form::model($news, ['method'=>'post', 'route'=>['admins.news.store'], 'class'=>'' ]) }}
+                <ul>
+                    <li class="flex mb-4">
+                        {{ Form::label('category', 'カテゴリー', ['class' => 'shrink-0 w-24']) }}
+                        <p class="shrink-0 w-24 text-[#FF0404]">【必須】</p>
+                        {{ Form::select('category', \CategoryConst::CATEGORY_LIST, null, ['id' => 'category', 'placeholder'=>'選択してください', 'class' => 'placeholder:text-slate-400 border-slate-300 rounded-md']) }}
+                    </li>
+                    <li class="flex mb-4">
+                        {{ Form::label('noticed_at', 'お知らせ日', ['class' => 'shrink-0 w-24']) }}
+                        <p class="shrink-0 w-24 text-[#FF0404]">【必須】</p>
+                        {{ Form::text('noticed_at', null, ['placeholder'=>'タイトルを入力', 'class' => 'w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                    </li>
+                    <li class="flex mb-4">
+                        {{ Form::label('title', 'タイトル', ['class' => 'shrink-0 w-24']) }}
+                        <p class="shrink-0 w-24 text-[#FF0404]">【必須】</p>
+                        {{ Form::text('title', null, ['placeholder'=>'タイトルを入力', 'class' => 'w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                    </li>
+                    <li class="flex mb-4">
+                        {{ Form::label('note', '注意書き', ['class' => 'shrink-0 w-48']) }}
+                        {{ Form::textarea('note', null, ['placeholder'=>'タイトルを入力', 'class'=>'align-top w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                    </li>
+                    <li class="flex mb-4">
+                        {{ Form::label('detail', 'お知らせ詳細', ['class' => 'shrink-0 w-48']) }}
+                        {{ Form::textarea('detail', null, ['placeholder'=>'タイトルを入力', 'class' => 'align-top w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                    </li>
+                    <li class="flex mb-4">
+                        {{ Form::label('iframe_path', 'iframeURL', ['class' => 'shrink-0 w-48']) }}
+                        {{ Form::textarea('iframe_path', null, ['placeholder'=>'タイトルを入力', 'class' => 'align-top w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                    </li>
+                    <li class="mb-4">
+                        {{ Form::label('preliminary_report_flag', '速報', ['class'=>'mr-1']) }}
+                        {{ Form::checkbox('preliminary_report_flag', 1, false, ['class'=>'']) }}
+                    </li>
+                    @if (count($news['news_documents']) != 0)
+                        @foreach ($news['news_documents'] as $key => $news_documents)
+                            <li class="flex mb-4">
+                                {{ Form::label('news_documents[' . $key . '][title]', '資料', ['class' => 'shrink-0 w-48']) }}
+                                <div class="flex w-full">
+                                    {{ Form::text('news_documents[' . $key . '][title]', null, ['placeholder'=>'資料名を入力', 'class' => 'w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                                    {{ Form::text('news_documents[' . $key . '][document_path]', null, ['placeholder'=>'資料名を入力', 'class' => 'w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                                </div>
+                            </li>
+                        @endforeach
+                    @else
+                        <li class="flex mb-4">
+                            {{ Form::label('news_documents[0][title]', '資料', ['class' => 'shrink-0 w-48']) }}
+                            <div class="flex w-full">
+                                {{ Form::text('news_documents[0][title]', null, ['placeholder'=>'資料名を入力', 'class' => 'w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                                {{ Form::text('news_documents[0][document_path]', null, ['placeholder'=>'資料名を入力', 'class' => 'w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                            </div>
+                        </li>
+                    @endif
+
+                    @if (count($news['news_links']) != 0)
+                    @foreach ($news['news_links'] as $key => $news_links)
+                        <li class="flex mb-4">
+                            {{ Form::label('news_links[' . $key . '][title]', 'リンク', ['class' => 'shrink-0 w-48']) }}
+                            {{ Form::text('news_links[' . $key . '][title]', null, ['placeholder'=>'タイトルを入力', 'class' => 'w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                            {{ Form::text('news_links[' . $key . '][link_path]', null, ['placeholder'=>'タイトルを入力', 'class' => 'w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                        </li>
+                    @endforeach
+                    @else
+                        <li class="flex mb-4">
+                            {{ Form::label('news_links[0][title]', 'リンク', ['class' => 'shrink-0 w-48']) }}
+                            {{ Form::text('news_links[0][title]', null, ['placeholder'=>'タイトルを入力', 'class' => 'w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                            {{ Form::text('news_links[0][link_path]', null, ['placeholder'=>'タイトルを入力', 'class' => 'w-full placeholder:text-slate-400 border-slate-300 rounded-md' ]) }}
+                        </li>
+                    @endif
+
+                </ul>
+                <div class=" mt-20 flex justify-center">
+                    <x-parts.form-button bgColor='black'>{{ count($news['news_links']) == 0 ? '登録する' : '編集する' }}</x-parts.form-button>
+                </div>
+            {{ Form::close() }}
+        </x-layout.container>
+    </section>
 </x-layout.layout>


### PR DESCRIPTION
## 概要
お知らせの登録・編集兼用画面
・初期リクエストの場合からで入力欄はからで表示
・すでにmodelのデータが存在するときはそのデータが表示される。
Form::modelに対象のモデルインスタンスを渡すことで入力部分と関連性を持たせている使用。newからの遷移では必ずインスタンスを渡さないといけない。

## 懸念点
お知らせ資料・お知らせリンクの記述がやや冗長な気もする。
bladeファイルの名前が登録・編集兼用なので変更すべきかも。

> TODO
jsにより資料・リンクのボックスを増やしたり減らしたりする処理を書いていない。
管理者用のお知らせのフロント画面に編集ボタンを表示していないので編集に関しては以下で動作確認を行なっている。
http://localhost/admins/news/1/edit
