### PR TITLE
本番環境でシンボリックリンクが使いない対応

### DIFF
--- a/app/Consts/CommonConst.php
+++ b/app/Consts/CommonConst.php
@@ -7,12 +7,12 @@ class CommonConst
     /**
      * ファイルパス
      */
-    const LIFTERS_FILE_PATH_NAME = 'public/lifter-images/';            // 選手画像
-    const NEWS_FILE_PATH_NAME = 'public/news-documents/';              // お知らせ資料
-    const REQUIREMENTS_FILE_PATH_NAME = 'public/result-requirements/'; // 大会要項
-    const RESULTS_FILE_PATH_NAME = 'public/result-results/';           // 大会結果
-    const TOP_FILE_PATH = 'public/top-images/';                        // トップ画像
-    const ASSOCIATION_DOCUMENT_PATH = 'public/association-documens/';  // 協会資料
+    const LIFTERS_FILE_PATH_NAME = 'lifter-images/';            // 選手画像
+    const NEWS_FILE_PATH_NAME = 'news-documents/';              // お知らせ資料
+    const REQUIREMENTS_FILE_PATH_NAME = 'result-requirements/'; // 大会要項
+    const RESULTS_FILE_PATH_NAME = 'result-results/';           // 大会結果
+    const TOP_FILE_PATH = 'top-images/';                        // トップ画像
+    const ASSOCIATION_DOCUMENT_PATH = 'association-documens/';  // 協会資料
 
     /**
      * top画面用ファイル名
@@ -74,7 +74,7 @@ class CommonConst
 
     /**
      * top画像リスト
-     * 
+     *
      * @param  array
      */
     const TOP_IMAGE_LIST = [
@@ -85,7 +85,7 @@ class CommonConst
 
     /**
      * ドキュメントリスト
-     * 
+     *
      * @param  array
      */
     const DOCUMENT_LIST = [

--- a/app/Consts/TitleConst.php
+++ b/app/Consts/TitleConst.php
@@ -13,12 +13,12 @@ class TitleConst
      * @param array
      */
     const TITLE_LIST = [
-        // 現在はどこにも使用しておらず、titleタグにトップの文字が入ってしまうのでコメントアウトする。
-        // 'Top' => [
-        //     0 => 'TOP',
-        //     1 => 'トップ',
-        //     2 => 'images/heros/hero1.png'
-        // ],
+        // トップにはタイトルタグのプレフィクスは必要ないのでから文字にする。s
+        'Top' => [
+            0 => 'TOP',
+            1 => '',
+            2 => 'images/heros/hero1.png'
+        ],
         'About' => [
             0 => 'ABOUT',
             1 => '協会について',

--- a/app/Http/Controllers/AboutController.php
+++ b/app/Http/Controllers/AboutController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
  */
 class AboutController extends Controller
 {
+
     public function index()
     {
         return view('about.index');

--- a/app/Services/LifterService.php
+++ b/app/Services/LifterService.php
@@ -163,7 +163,7 @@ class LifterService
     {
         $datas = $request->all();
         if ($request->file('image_path')) {
-            $path = $request->file('image_path')->store('public/lifter-images');
+            $path = $request->file('image_path')->store(\CommonConst::LIFTERS_FILE_PATH_NAME);
             $datas['image_path'] = basename($path);
         }
         return $datas;

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -32,13 +32,15 @@ return [
 
         'local' => [
             'driver' => 'local',
-            'root' => storage_path('app'),
+            // 'root' => storage_path('app'),
+            'root' => public_path('/storage'),
             'throw' => false,
         ],
 
         'public' => [
             'driver' => 'local',
-            'root' => storage_path('app/public'),
+            // 'root' => storage_path('app/public'),
+            'root' => public_path('/storage'),
             'url' => env('APP_URL').'/storage',
             'visibility' => 'public',
             'throw' => false,

--- a/database/factories/LifterFactory.php
+++ b/database/factories/LifterFactory.php
@@ -26,7 +26,7 @@ class LifterFactory extends Factory
             'category' => $this->faker->numberBetween(1, 5),
             'affiliation_id' => $this->faker->numberBetween(1, 5),
             'weight_class' => $this->faker->numberBetween(1, 20),
-            'image_path' => $this->faker->image(storage_path('app/public/lifter-images'), 640, 480, null, false),
+            'image_path' => $this->faker->image(public_path('storage/' . \CommonConst::LIFTERS_FILE_PATH_NAME), 640, 480, null, false),
         ];
     }
 

--- a/resources/views/results/index.blade.php
+++ b/resources/views/results/index.blade.php
@@ -68,10 +68,18 @@
                             <li class="p-[10px] shrink-0 w-[150px] h-11 border-l border-inherit pc-sp:w-full"><span class="hidden pc-sp:inline font-black mr-3">開催日</span>{{ date('m/d', strtotime($value['started_at'])) }} ~ {{ date('m/d', strtotime($value['ended_at'])) }}</li>
                             <li class="p-[10px] shrink-1 w-[415px] h-11 border-l border-inherit pc-sp:w-full"><span class="hidden pc-sp:inline font-black mr-3">大会名</span>{{ $value['name'] }}</li>
                             <li class="p-[10px] shrink-1 w-[225px] h-11 border-l border-inherit pc-sp:w-full"><span class="hidden pc-sp:inline font-black mr-3">開催地</span>{{ $value['venue'] }}</li>
-                            <!-- TODO: href="{{ $value['requirement_path'] }}" 差し替え -->
-                            <li class="p-[10px] shrink-0 w-20 h-11 border-l border-inherit  pc-sp:w-full pc-sp:flex"><span class="hidden pc-sp:inline font-black mr-3">要　項</span><a href=""><img src="images/parts/pdf.png" alt="pdf" class=" w-5 m-auto pc-sp:ml-5"></a></li>
-                            <!-- TODO: href="{{ $value['result_path'] }}" 差し替え -->
-                            <li class="p-[10px] shrink-0 w-20 h-11 border-l border-inherit  pc-sp:w-full pc-sp:flex"><span class="hidden pc-sp:inline font-black mr-3">結　果</span><a href=""><img src="images/parts/pdf.png" alt="pdf" class=" w-5 m-auto pc-sp:ml-5"></a></li>
+                            <li class="p-[10px] shrink-0 w-20 h-11 border-l border-inherit  pc-sp:w-full pc-sp:flex">
+                                <span class="hidden pc-sp:inline font-black mr-3">要　項</span>
+                                <a class="mb-5 text-sm block underline" href="{{ asset('storage/' . \CommonConst::REQUIREMENTS_FILE_PATH_NAME . $value['requirement_path']) }}" download="{{ $value['name'] }}.pdf">
+                                    <img src="images/parts/pdf.png" alt="pdf" class=" w-5 m-auto pc-sp:ml-5">
+                                </a>
+                            </li>
+                            <li class="p-[10px] shrink-0 w-20 h-11 border-l border-inherit  pc-sp:w-full pc-sp:flex">
+                                <span class="hidden pc-sp:inline font-black mr-3">結　果</span>
+                                <a class="mb-5 text-sm block underline" href="{{ asset('storage/' . \CommonConst::RESULTS_FILE_PATH_NAME . $value['result_path']) }}" download="{{ $value['name'] }}.pdf">
+                                    <img src="images/parts/pdf.png" alt="pdf" class=" w-5 m-auto pc-sp:ml-5">
+                                </a>
+                            </li>
                         </ul>
                     </div>
                     @endforeach


### PR DESCRIPTION
保存するためのファイルをstorage/app/publicからpublic/storageに変更
本番環境実行ログ
シンボリックリンクを削除
`unlink storage`
保存先フォルダを作成
`mkdir public/storage`
本番環境で閲覧権限がなかったので以下を実行
`chmod -R 777 public/storage/`

ローカル環境でやること。
シンボリックリンクを削除
`unlink storage`
保存先フォルダを作成
`mkdir public/storage`
データの入れ直し
`sail artisan migrate:reset`
`sail artisan migrate --seed`
元のファイルを消去
storage/app/public以下のファイルを消去する
`rm -rf storage/app/public`